### PR TITLE
Add env config for Formspree

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_FORMSPREE_URL=https://formspree.io/f/mvgrrqzb

--- a/README.md
+++ b/README.md
@@ -41,3 +41,12 @@ git clone https://github.com/Marekpisetsky/candela-web.git
 cd candela-web
 npm install
 npm run dev
+```
+
+### Variables de entorno
+
+Crea un archivo `.env` en la raíz del proyecto definiendo la URL de tu formulario de Formspree:
+
+```bash
+VITE_FORMSPREE_URL=https://formspree.io/f/mvgrrqzb
+```

--- a/src/sections/Contacto.jsx
+++ b/src/sections/Contacto.jsx
@@ -16,7 +16,7 @@ function Contacto() {
 
   const handleSubmit = async e => {
     e.preventDefault();
-    const response = await fetch("https://formspree.io/f/mvgrrqzb", {
+    const response = await fetch(import.meta.env.VITE_FORMSPREE_URL, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(formData),


### PR DESCRIPTION
## Summary
- use `import.meta.env.VITE_FORMSPREE_URL` in Contacto form
- document the environment variable in the README
- add a default `.env` file with the variable

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_686589092ba88330bd2d58d681491228