### PR TITLE
Remove env from repo and add example

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-VITE_FORMSPREE_URL=https://formspree.io/f/mvgrrqzb

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for Candela
+# Replace with your Formspree URL
+VITE_FORMSPREE_URL=

--- a/README.md
+++ b/README.md
@@ -45,10 +45,12 @@ npm run dev
 
 ### Variables de entorno
 
-Crea un archivo `.env` en la raíz del proyecto definiendo la URL de tu formulario de Formspree:
+Utiliza el archivo de ejemplo `.env.example`. Cópialo como `.env` y reemplaza el valor con la URL de tu formulario de Formspree:
 
 ```bash
-VITE_FORMSPREE_URL=https://formspree.io/f/mvgrrqzb
+cp .env.example .env
+# Edita .env y asigna tu URL real
+VITE_FORMSPREE_URL=https://formspree.io/tu-endpoint
 ```
 
 


### PR DESCRIPTION
## Summary
- stop tracking `.env`
- add `.env.example` with placeholder
- guide users to copy `.env.example` in the README

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686590162800833081e94aaab63eaceb