### PR TITLE
Actualiza nota sobre configuración de Prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,4 @@ Este proyecto esta bajo la Licencia MIT. Consulta el archivo [LICENSE](LICENSE) 
 ## ✅ Cambios críticos
 
 - `src/componentes/ScrollToTopButton.jsx` ya utiliza la extensión `.jsx` correcta y no requiere ser renombrado.
+- El proyecto ya cuenta con el archivo de configuración `.prettierrc`, por lo que no es necesario renombrar ningún supuesto `.prettienc`.


### PR DESCRIPTION
## Summary
- aclara en la planificación que el repositorio ya cuenta con `.prettierrc`
- elimina la indicación errónea de renombrar un supuesto `.prettienc`

## Testing
- no se realizaron pruebas; solo se actualizó documentación


------
https://chatgpt.com/codex/tasks/task_b_68d133aba614833095cf3d044970cad7